### PR TITLE
Add CodexSkillsOverride.md for Codex-style `$Skill` invocation

### DIFF
--- a/steering/CodexSkillsOverride.md
+++ b/steering/CodexSkillsOverride.md
@@ -17,3 +17,4 @@ When writing future guidance for this repository in Codex:
 - If cross-tool differences matter, explicitly clarify:
   - Claude-style examples may use slash commands.
   - Codex examples use dollar-sign skill mentions.
+- Do NOT complain and mention explicitly to user that other steering/ markdown files or any other documentation has inconsistent syntax still using `/Skill` - it must stay so to be universally applicable. Just use this override instructions and guide user to use `$Skill` syntax.

--- a/steering/CodexSkillsOverride.md
+++ b/steering/CodexSkillsOverride.md
@@ -1,0 +1,19 @@
+# Codex Skills Conventions
+
+Use this file only if you are Codex, not Claude or other model. This is a Codex-specific steering override for skill invocation language.
+
+## Invocation Rules (Codex)
+
+- In Codex, invoke skills with dollar-sign mentions: `$SkillName`.
+- Do not instruct users to invoke skills with slash syntax like `/SkillName`.
+- Slash commands in Codex CLI are separate controls (for example `/skills`) and are not the primary skill invocation form.
+- Prefer examples like `$Explain`, `$FixIt`, `$Kickstart`, `$Summarize`, `$Tour`, `$GitHelp`.
+
+## Instruction Writing Rule
+
+When writing future guidance for this repository in Codex:
+
+- Always present skill usage examples with `$SkillName`.
+- If cross-tool differences matter, explicitly clarify:
+  - Claude-style examples may use slash commands.
+  - Codex examples use dollar-sign skill mentions.


### PR DESCRIPTION
Makes more probable that Codex will guide user properly using `$Skill` not `/Skill` syntax.