### PR TITLE
feat: prompt for install scope, document global skill install

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,15 +27,21 @@ Before setup, verify the user has what they need:
 
 ## Build and Deploy
 
-If the user wants to deploy agents and skills to all providers:
+If the user wants to deploy agents and skills to all providers, first ask where they want skills installed:
+
+- **Workspace** (this project only): `make install SCOPE=workspace`
+- **Global** (all projects): `make install SCOPE=user`
+
+Most users want global — skills like `/Explain` and `/GitHelp` are useful everywhere.
+
+For first-time setup, initialize forge-lib before running the install command:
 
 ### POSIX shells (macOS/Linux/WSL/Git Bash)
 
 ```bash
-git submodule update --init lib   # initialize forge-lib (first time only)
-make -C lib build                 # build Rust binaries (first time only)
-make install                      # deploy 1 agent + 7 skills to all providers
-make verify                       # confirm everything deployed
+git submodule update --init lib     # initialize forge-lib (first time only)
+make -C lib build                   # build Rust binaries (first time only)
+make verify                         # confirm everything deployed
 ```
 
 ### Windows PowerShell fallback

--- a/Makefile
+++ b/Makefile
@@ -46,19 +46,8 @@ check-lib:
 	  exit 1; \
 	fi
 
-install: check-lib
-	@if [ "$(origin SCOPE)" = "command line" ]; then \
-	  $(MAKE) install-agents install-skills; \
-	else \
-	  printf "\nInstall skills for:\n  [1] This project only (workspace)\n  [2] All projects — use skills in any directory (user)\nChoice [1/2]: "; \
-	  read choice; \
-	  if [ "$$choice" = "2" ]; then \
-	    $(MAKE) SCOPE=user install-agents install-skills; \
-	  else \
-	    $(MAKE) SCOPE=workspace install-agents install-skills; \
-	  fi; \
-	fi
-	@echo "Installation complete. Restart your session or reload agents/skills."
+install: check-lib install-agents install-skills
+	@echo "Installation complete (SCOPE=$(SCOPE)). Restart your session or reload agents/skills."
 
 clean: clean-agents clean-skills
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,18 @@ check-lib:
 	  exit 1; \
 	fi
 
-install: check-lib install-agents install-skills
+install: check-lib
+	@if [ "$(origin SCOPE)" = "command line" ]; then \
+	  $(MAKE) install-agents install-skills; \
+	else \
+	  printf "\nInstall skills for:\n  [1] This project only (workspace)\n  [2] All projects — use skills in any directory (user)\nChoice [1/2]: "; \
+	  read choice; \
+	  if [ "$$choice" = "2" ]; then \
+	    $(MAKE) SCOPE=user install-agents install-skills; \
+	  else \
+	    $(MAKE) SCOPE=workspace install-agents install-skills; \
+	  fi; \
+	fi
 	@echo "Installation complete. Restart your session or reload agents/skills."
 
 clean: clean-agents clean-skills

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ claude
 
 That's it. You're set up.
 
+### Optional: Make skills available everywhere
+
+By default, skills only work inside the `forge-learn` directory. To use `/Explain`, `/GitHelp`, and other skills in any project:
+
+```bash
+make install SCOPE=user
+```
+
+This installs skills globally so they're available whenever you run `claude`, regardless of which project you're in.
+
 ## Available Skills
 
 | Skill | What it does |

--- a/steering/Levels.md
+++ b/steering/Levels.md
@@ -38,6 +38,8 @@ Use the AI to understand files and save your work with git.
 
 > **Privacy tip**: Your `steering/` files contain personal info (name, goals). If you push to a public repository, this becomes visible. Consider keeping your fork private or reviewing these files before pushing.
 
+> **Tip**: Skills are installed per-project by default. To use `/Explain`, `/GitHelp`, and others in *any* project, install globally: `make install SCOPE=user`. Skills will then be available wherever you run Claude Code.
+
 - [ ] Used /Explain on a file in your project
 - [ ] Made your first git commit (try: /GitHelp save my progress)
 - [ ] Used /GitHelp to check what changed or review your history


### PR DESCRIPTION
## Summary

- `make install` now prompts the user to choose between project-only (workspace) or global (user) installation when `SCOPE` is not explicitly set — removes a silent footgun where skills only work in one directory
- README quick start documents the optional global install step (`make install SCOPE=user`)
- Level 3 in `steering/Levels.md` adds a contextual tip about global install at the point in the learning path where it becomes relevant

## Test plan

- [ ] Run `make install` without `SCOPE` — confirm prompt appears
- [ ] Choose option 1 — confirm skills install to `.claude/skills/` (workspace)
- [ ] Choose option 2 — confirm skills install to `~/.claude/skills/` (user)
- [ ] Run `make install SCOPE=user` — confirm prompt is skipped
- [ ] Verify README quick start section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)