### PR TITLE
docs: add windows install and verify guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ make test             # validate-module convention checks
 make clean            # remove installed agents + skills
 ```
 
+Windows note: if `make` fails in PowerShell due POSIX shell syntax, use the Windows fallback in `INSTALL.md` (`cargo build --release` + `install-agents.exe` / `install-skills.exe`).
+
 ## Project Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ make test             # validate-module convention checks
 make lint             # mdschema + shellcheck
 ```
 
+Windows note: these Make targets use POSIX shell syntax. In PowerShell, use the fallback commands in `INSTALL.md` (`cargo build --release` + `install-agents.exe` / `install-skills.exe`) or run `make` from WSL/Git Bash.
+
 ## Identity
 
 Read `steering/Identity.md` for the user's name, preferences, and experience level. Adjust your communication style accordingly.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,6 +22,8 @@ make test             # validate-module convention checks
 make clean            # remove installed agents + skills
 ```
 
+Windows note: these `make` targets are POSIX-oriented. In PowerShell, use the fallback in `INSTALL.md` (`cargo build --release` and run `lib\\target\\release\\install-*.exe` directly), or run `make` from WSL/Git Bash.
+
 ## Skills
 
 | Skill | Responsibilities |
@@ -57,6 +59,8 @@ Each skill directory contains:
 git submodule add https://github.com/N4M3Z/forge-learn.git modules/forge-learn
 cd modules/forge-learn && make install SCOPE=workspace
 ```
+
+Windows PowerShell fallback: use `cargo build --release --manifest-path lib/Cargo.toml`, then run `lib\\target\\release\\install-agents.exe` and `lib\\target\\release\\install-skills.exe` directly (see root `INSTALL.md` for full command sequence).
 
 ### Makefile Integration
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ claude
 
 1. Open `steering/Identity.md` in any text editor — change `Your Name` to your actual name and save
 2. Open `steering/Goals.md` — replace the example goals with yours
-3. Run `make install` to deploy agents and skills to all providers
+3. Deploy agents and skills:
+   - Mac/Linux/WSL/Git Bash: run `make install`
+   - Windows PowerShell fallback: run the Windows block in [INSTALL.md](INSTALL.md) (`cargo build --release` + `install-*.exe`)
 4. Start Claude Code: `claude`
 5. Type `/Tour`
 
@@ -135,7 +137,7 @@ Your AI tool reads the files in this directory at the start of every session:
 - `steering/Identity.md` tells it who you are
 - `steering/Goals.md` tells it what you're working toward
 - `skills/*/SKILL.md` gives it abilities you can invoke by name
-- `agents/*.md` gives it personas it can adopt (deployed by `make install`)
+- `agents/*.md` gives it personas it can adopt (deployed by `make install` or Windows fallback commands in `INSTALL.md`)
 
 You change a file, the AI's behavior changes. That's the entire system.
 
@@ -161,7 +163,8 @@ Clone a module into `modules/` and ask your AI to help set it up. For automated 
 - [Git](https://git-scm.com/downloads) — to download and manage this repository
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — the AI tool that reads these files
 - A text editor — anything works (VS Code, Notepad, TextEdit, Sublime, vim)
-- **Windows**: Works natively on Windows 10+. See [platform setup](https://code.claude.com/docs/en/setup#platform-specific-setup) for details.
+- Rust toolchain (`cargo`) for first-time local binary builds (`lib/`)
+- **Windows**: Works natively on Windows 10+. `make` recipes are POSIX-style; use WSL/Git Bash for `make install`, or use the PowerShell fallback in [INSTALL.md](INSTALL.md).
 
 ## License
 

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -42,7 +42,7 @@ Expected skills: Explain, FixIt, GitHelp, Kickstart, Progress, Summarize, Tour.
 
 ## Check 5: Agent Available
 
-Verify `agents/CodeHelper.md` exists (source file). After `make install`, it deploys to `.claude/agents/CodeHelper.md`. If the source is missing, the starter agent won't be available for Level 5 progression.
+Verify `agents/CodeHelper.md` exists (source file). After install (`make install` on POSIX shells, or `install-agents.exe` on Windows PowerShell), it deploys to `.claude/agents/CodeHelper.md`. If the source is missing, the starter agent won't be available for Level 5 progression.
 
 ## Reporting Results
 


### PR DESCRIPTION
## Summary
- add Windows-specific install prerequisites and fallback commands in INSTALL.md
- document PowerShell fallback when POSIX Make targets fail
- update README/VERIFY/AGENTS/CLAUDE/GEMINI to reference the Windows path consistently

## Notes
- docs-only change
- no code or behavior changes