### PR TITLE
fix: add missing Progress skill + change default codex model to 5.3

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -14,6 +14,7 @@ skills:
         FixIt:
         GitHelp:
         Kickstart:
+        Progress:
         Refactor:
         Summarize:
         Tour:
@@ -23,6 +24,7 @@ skills:
         FixIt:
         GitHelp:
         Kickstart:
+        Progress:
         Refactor:
         Summarize:
         Tour:
@@ -32,6 +34,7 @@ skills:
         FixIt:
         GitHelp:
         Kickstart:
+        Progress:
         Refactor:
         Summarize:
         Tour:
@@ -49,8 +52,8 @@ providers:
         fast: gemini-2.0-flash
         strong: gemini-2.5-pro
     codex:
-        fast: o4-mini
-        strong: o4-mini
+        fast: gpt-5.3-codex
+        strong: gpt-5.3-codex
     opencode:
         fast: claude-sonnet-4-6
         strong: claude-opus-4-6


### PR DESCRIPTION
Fixes https://github.com/N4M3Z/forge-learn/issues/2  and sets latest codex-5.3 model as default for codex instead of the legacy model