### PR TITLE
fix: add Progress skill to all providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,7 @@ Platform directories (`.claude/`, `.gemini/`, `.codex/`, `.opencode/`) are gener
 
 ### Provider Routing
 
-`defaults.yaml` uses provider-keyed allowlists. All skills deploy to all
-providers.
+`defaults.yaml` uses provider-keyed allowlists.
 
 ## Agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Platform directories (`.claude/`, `.gemini/`, `.codex/`, `.opencode/`) are gener
 | Skill | Purpose |
 |-------|---------|
 | **Tour** | Walk through setup, directories, and available skills |
-| **Progress** | Show current level and suggest next steps (Claude only) |
+| **Progress** | Show current level and suggest next steps |
 | **Explain** | Explain any file, error, or concept in plain language |
 | **FixIt** | Diagnose problems and propose fixes |
 | **GitHelp** | Translate plain English into git commands |
@@ -51,8 +51,8 @@ Platform directories (`.claude/`, `.gemini/`, `.codex/`, `.opencode/`) are gener
 
 ### Provider Routing
 
-`defaults.yaml` uses provider-keyed allowlists. Most skills deploy to all
-providers. **Progress** is Claude-only (uses Claude Code progression features).
+`defaults.yaml` uses provider-keyed allowlists. All skills deploy to all
+providers.
 
 ## Agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Skills are in `skills/*/SKILL.md`. Each skill is invoked by typing its name (e.g
 | Skill | What it does |
 |-------|-------------|
 | **Tour** | Walk through setup, directories, and available skills |
-| **Progress** | Show current level and suggest next steps (Claude only) |
+| **Progress** | Show current level and suggest next steps |
 | **Explain** | Explain any file, error, or concept in plain language |
 | **FixIt** | Diagnose problems and propose fixes |
 | **GitHelp** | Translate plain English into git commands |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,13 +29,12 @@ Windows note: these `make` targets are POSIX-oriented. In PowerShell, use the fa
 | Skill | Responsibilities |
 |:------|:-----------------|
 | `Tour` | Setup walkthrough, directory explanation, getting started guidance |
+| `Progress` | Show current level, suggest next steps, and update level progression |
 | `Explain` | Plain language explanation of files, errors, and concepts |
 | `FixIt` | Problem diagnosis and fix proposals |
 | `GitHelp` | Plain English to git command translation |
 | `Kickstart` | Idea-to-plan conversion with starter files |
 | `Summarize` | Key point extraction into structured summaries |
-
-Note: `Progress` is Claude Code-only and not deployed to Gemini.
 
 ## Agents
 

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -14,6 +14,7 @@ skills:
         FixIt:
         GitHelp:
         Kickstart:
+        Progress:
         Refactor:
         Summarize:
         Tour:
@@ -23,6 +24,7 @@ skills:
         FixIt:
         GitHelp:
         Kickstart:
+        Progress:
         Refactor:
         Summarize:
         Tour:
@@ -32,6 +34,7 @@ skills:
         FixIt:
         GitHelp:
         Kickstart:
+        Progress:
         Refactor:
         Summarize:
         Tour:


### PR DESCRIPTION
- add progress skill to all providers in defaults.yaml
- remove unnecessary comments about progress skill being usable claude only from CLAUDE.md, GEMINI.md and AGENTS.md